### PR TITLE
Prevent encoding the index name

### DIFF
--- a/aws4.js
+++ b/aws4.js
@@ -302,8 +302,8 @@ RequestSigner.prototype.parsePath = function() {
   // all services don't encode characters > 255 correctly
   // So if there are non-reserved chars (and it's not already all % encoded), just encode them all
   if (/[^0-9A-Za-z!'()*\-._~%/]/.test(path)) {
-    path = path.split('/').map(function(piece) {
-      return encodeURIComponent(decodeURIComponent(piece))
+    path = path.split('/').map(function(piece, i) {
+        return i === 0 ? piece : encodeURIComponent(decodeURIComponent(piece))
     }).join('/')
   }
 


### PR DESCRIPTION
In Elasticsearch, the first parameter of the path is the index name. When using single-index search without special characters everything works fine.

As soon as you try to use multi-index search or your index name contains special characters everything breaks.

This happens because in lines 304-307 we encode the full url. The same code is used in other AWS services so I am not sure if there is specific reason for doing so.

In ES though, the first parameter is the index name. When you use multi-index search the requested path should be something like this `categories,products/_msearch` and after encoding it becomes `categories%2Cproducts/_msearch` which fails.

Instead we just skip from encoding the first part for now.